### PR TITLE
Ajuste na regra de cancelamento de proposta na edição de um anúncio

### DIFF
--- a/database/02-createInitialize.sql
+++ b/database/02-createInitialize.sql
@@ -25,8 +25,9 @@ insert into situacao values
 (32, 'Proposta confirmada'),
 (33, 'Proposta recusada'),
 (34, 'Proposta cancelada'),
-(35, 'Encontro realizado'),
-(36, 'Encontro não realizado'),
+(35, 'Proposta em análise'),
+(36, 'Encontro realizado'),
+(37, 'Encontro não realizado'),
 (41, 'Denúncia criada'),
 (42, 'Denúncia gerenciada');
 

--- a/src/main/java/com/api/doarmais/events/PropostaCanceladaEdicaoAnuncioEvent.java
+++ b/src/main/java/com/api/doarmais/events/PropostaCanceladaEdicaoAnuncioEvent.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class PropostaCanceladaEvent {
+public class PropostaCanceladaEdicaoAnuncioEvent {
 
   private PropostaModel propostaModel;
 }

--- a/src/main/java/com/api/doarmais/models/tabelas/AnuncioModel.java
+++ b/src/main/java/com/api/doarmais/models/tabelas/AnuncioModel.java
@@ -1,5 +1,6 @@
 package com.api.doarmais.models.tabelas;
 
+import com.api.doarmais.dtos.request.EditarAnuncioRequestDto;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
@@ -72,4 +73,17 @@ public class AnuncioModel {
 
   @Column(name = "quantidade_proposta")
   private Integer quantidadeProposta;
+
+    public boolean verficarTrocaInfoPrincipal(EditarAnuncioRequestDto anuncioEditado) {
+      if(!this.cep.equals(anuncioEditado.getCep()))
+        return true;
+
+      if(!this.getNumero().equals(anuncioEditado.getNumero()))
+        return true;
+
+      if(!this.getDataInicioDisponibilidade().equals(anuncioEditado.getDataInicioDisponibilidade()))
+        return true;
+
+      return !this.getDataFimDisponibilidade().equals(anuncioEditado.getDataFimDisponibilidade());
+    }
 }

--- a/src/main/java/com/api/doarmais/models/tabelas/ItemAnuncioModel.java
+++ b/src/main/java/com/api/doarmais/models/tabelas/ItemAnuncioModel.java
@@ -38,6 +38,9 @@ public class ItemAnuncioModel {
   private String descricao;
 
     public Boolean verificarTrocaitem(EditarItemAnuncioRequestDto itemDto) {
+      if(!this.getNome().equals(itemDto.getNome()))
+        return true;
+
       return !this.getQuantidade().equals(itemDto.getQuantidade());
     }
 }

--- a/src/main/java/com/api/doarmais/models/tabelas/SituacaoModel.java
+++ b/src/main/java/com/api/doarmais/models/tabelas/SituacaoModel.java
@@ -31,8 +31,9 @@ public class SituacaoModel {
   public static final Integer PROPOSTA_CONFIRMADA = 32;
   public static final Integer PROPOSTA_RECUSADA = 33;
   public static final Integer PROPOSTA_CANCELADA = 34;
-  public static final Integer ENCONTRO_REALIZADO = 35;
-  public static final Integer ENCONTRO_NAO_REALIZADO = 36;
+  public static final Integer PROPOSTA_EM_ANALISE = 35;
+  public static final Integer ENCONTRO_REALIZADO = 36;
+  public static final Integer ENCONTRO_NAO_REALIZADO = 37;
 
   public static final Integer DENUNCIA_CRIADA = 41;
   public static final Integer DENUNCIA_GERENCIADA = 42;

--- a/src/main/java/com/api/doarmais/notifications/NotificadorPropostaCanceladaEdicaoAnuncio.java
+++ b/src/main/java/com/api/doarmais/notifications/NotificadorPropostaCanceladaEdicaoAnuncio.java
@@ -1,5 +1,6 @@
 package com.api.doarmais.notifications;
 
+import com.api.doarmais.events.PropostaCanceladaEdicaoAnuncioEvent;
 import com.api.doarmais.events.PropostaCriadaEvent;
 import com.api.doarmais.models.tabelas.ItemAnuncioPropostaModel;
 import com.api.doarmais.models.tabelas.PropostaModel;
@@ -7,14 +8,12 @@ import com.api.doarmais.models.tabelas.UsuarioModel;
 import com.api.doarmais.services.ItemAnuncioPropostaService;
 import com.api.doarmais.services.UsuarioService;
 import jakarta.mail.MessagingException;
-import jakarta.mail.internet.MimeMessage;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.event.EventListener;
 import org.springframework.mail.MailSendException;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
-import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.EnableAsync;
 
@@ -23,7 +22,7 @@ import java.util.List;
 
 @EnableAsync
 @Configuration
-public class NotificadorPropostaCancelada implements Notificador<PropostaCriadaEvent> {
+public class NotificadorPropostaCanceladaEdicaoAnuncio implements Notificador<PropostaCanceladaEdicaoAnuncioEvent> {
 
   @Autowired private JavaMailSender sender;
 
@@ -33,20 +32,25 @@ public class NotificadorPropostaCancelada implements Notificador<PropostaCriadaE
 
   @EventListener
   @Async
-  public void enviar(PropostaCriadaEvent propostaCriadaEvent) throws MessagingException {
+  public void enviar(PropostaCanceladaEdicaoAnuncioEvent propostaCanceladaEdicaoAnuncioEvent) throws MessagingException {
     SimpleMailMessage message = new SimpleMailMessage();
 
-    PropostaModel proposta = propostaCriadaEvent.getPropostaModel();
-    UsuarioModel usuario = usuarioService.buscarUsuarioPorEmail(proposta.getAnuncioModel().getUsuarioModel().getEmail());
+    PropostaModel proposta = propostaCanceladaEdicaoAnuncioEvent.getPropostaModel();
 
-    message.setTo(usuario.getEmail());
+    message.setTo(proposta.getUsuarioModel().getEmail());
     message.setFrom("doar.mais@outlook.com");
     message.setSubject("Doar+ - Proposta cancelada");
 
+    StringBuilder itens = new StringBuilder();
+    List<ItemAnuncioPropostaModel> itemAnuncioPropostaModelList = itemAnuncioPropostaService.buscarPorProposta(proposta.getId());
+    for (ItemAnuncioPropostaModel itemProposta : itemAnuncioPropostaModelList) {
+      itens.append("Item - ").append(itemProposta.getItemAnuncioModel().getNome()).append("\n").append("Quantidade - ").append(itemProposta.getQuantidadeSolicitada()).append("\n\n");
+    }
+
     message.setText("Olá, " + proposta.getUsuarioModel().getNome() + "!\n\n" +
-                    "Sua proposta " + proposta.getAnuncioModel().getTitulo() +
-                    " agendada para " + proposta.getDataAgendada().format(DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm:ss")) +
-                    " foi cancelada, pois o usuário que criou precisou editar o anúncio!");
+                    "Sua proposta - " + proposta.getAnuncioModel().getTitulo() + "\n\n" + itens +
+                    "Agendada para - " + proposta.getDataAgendada().format(DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm:ss")) + "\n" +
+                    "Foi cancelada, pois a pessoa que criou precisou editar o anúncio!");
 
     try {
       sender.send(message);

--- a/src/main/java/com/api/doarmais/repositories/ItemAnuncioPropostaRepository.java
+++ b/src/main/java/com/api/doarmais/repositories/ItemAnuncioPropostaRepository.java
@@ -3,6 +3,7 @@ package com.api.doarmais.repositories;
 import com.api.doarmais.models.tabelas.ItemAnuncioPropostaModel;
 import com.api.doarmais.models.tabelas.PropostaModel;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -10,4 +11,8 @@ import java.util.List;
 @Repository
 public interface ItemAnuncioPropostaRepository extends JpaRepository<ItemAnuncioPropostaModel, Integer> {
     List<ItemAnuncioPropostaModel> findByPropostaModelId(Integer id);
+
+    @Query("select t from ItemAnuncioPropostaModel t where t.itemAnuncioModel.id = ?1 and t.propostaModel.situacaoModel.id in (31, 32, 35)")
+    List<ItemAnuncioPropostaModel> buscarPorItemAnuncioIdQuery(Integer id);
+
 }

--- a/src/main/java/com/api/doarmais/repositories/PropostaRepository.java
+++ b/src/main/java/com/api/doarmais/repositories/PropostaRepository.java
@@ -2,12 +2,34 @@ package com.api.doarmais.repositories;
 
 import com.api.doarmais.models.tabelas.AnuncioModel;
 import com.api.doarmais.models.tabelas.PropostaModel;
+import feign.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 @Repository
 public interface PropostaRepository extends JpaRepository<PropostaModel, Integer> {
-    List<PropostaModel> findByAnuncioModelIdAndSituacaoModelId(Integer id, int i);
+    @Query("select t from PropostaModel t where t.anuncioModel.id = ?1 and t.situacaoModel.id in (31, 32)")
+    List<PropostaModel> buscarPorAnuncioIdQuery(Integer id);
+
+    @Transactional
+    @Modifying
+    @Query("update PropostaModel set situacaoModel.id = 35 where anuncioModel.id = ?1 and situacaoModel.id in (31, 32)")
+    void cancelarTodasPropostaAnuncioQuery(Integer id);
+
+    @Transactional
+    @Modifying
+    @Query("update PropostaModel set situacaoModel.id = 34 where situacaoModel.id = 35")
+    void cancelarPropostaQuery();
+
+    @Transactional
+    @Modifying()
+    @Query("update PropostaModel set situacaoModel.id = 35 where id = ?1")
+    void propostaEmAnaliseQuery(Integer id);
+
+    List<PropostaModel> findBySituacaoModelId(int i);
 }

--- a/src/main/java/com/api/doarmais/services/ItemAnuncioPropostaService.java
+++ b/src/main/java/com/api/doarmais/services/ItemAnuncioPropostaService.java
@@ -2,7 +2,6 @@ package com.api.doarmais.services;
 
 import com.api.doarmais.dtos.request.ItemPropostaRequestDto;
 import com.api.doarmais.dtos.request.PropostaRequestDto;
-import com.api.doarmais.events.PropostaCanceladaEvent;
 import com.api.doarmais.models.tabelas.*;
 import com.api.doarmais.repositories.AnuncioRepository;
 import com.api.doarmais.repositories.ItemAnuncioPropostaRepository;
@@ -59,6 +58,6 @@ public class ItemAnuncioPropostaService {
         }
       }
 
-      eventPublisher.publishEvent(new PropostaCanceladaEvent(proposta));
+
     }
 }


### PR DESCRIPTION
Apenas itens afetados tem seus anúncios cancelados, exceto se um item principal foi alterado, nesse caso todas as propostas são canceladas