### PR TITLE
Cancelamento de anúncio e controle para enviar possível punição

### DIFF
--- a/database/01-scriptDoarMais.sql
+++ b/database/01-scriptDoarMais.sql
@@ -153,6 +153,15 @@ create table autenticacao_email(
     primary key (id)
 );
 
+create table punicao(
+    id int not null auto_increment,
+    id_usuario int,
+    data_agendada datetime,
+    data_cancelamento datetime,
+    motivo text,
+    primary key (id)
+);
+
 -- FIM BANCO
 
 -- CRIAÇÃO DAS VIEWS

--- a/database/02-createInitialize.sql
+++ b/database/02-createInitialize.sql
@@ -29,7 +29,9 @@ insert into situacao values
 (36, 'Encontro realizado'),
 (37, 'Encontro não realizado'),
 (41, 'Denúncia criada'),
-(42, 'Denúncia gerenciada');
+(42, 'Denúncia gerenciada'),
+(51, 'Punição não verificada'),
+(52, 'Punição verificada');
 
 insert into tipo_anuncio values
 (1, 'Doação'),

--- a/src/main/java/com/api/doarmais/controllers/interfaces/AtividadeController.java
+++ b/src/main/java/com/api/doarmais/controllers/interfaces/AtividadeController.java
@@ -2,6 +2,7 @@ package com.api.doarmais.controllers.interfaces;
 
 import com.api.doarmais.dtos.request.AnuncioRequestDto;
 import com.api.doarmais.dtos.request.EditarAnuncioRequestDto;
+import com.api.doarmais.dtos.request.MotivoCancelamentoDto;
 import com.api.doarmais.dtos.request.PropostaRequestDto;
 import com.api.doarmais.dtos.response.AnuncioResponseDto;
 import com.api.doarmais.dtos.response.PropostaResponseDto;
@@ -21,8 +22,10 @@ public interface AtividadeController {
 
   @Operation(description = "Endpoint utilizado para editar um anúncio.")
   @PatchMapping("/{id}")
-  public ResponseEntity<AnuncioResponseDto> editarAnuncio( @PathVariable("id") Integer id,
+  public ResponseEntity<AnuncioResponseDto> editarAnuncio(@PathVariable("id") Integer id,
           @Valid @RequestBody EditarAnuncioRequestDto editarAnuncioRequestDto);
 
-
+  @Operation(description = "Endpoint utilizado para cancelar um anúncio.")
+  @PatchMapping("/cancelar/{id}")
+  public ResponseEntity<AnuncioResponseDto> cancelarAnuncio(@PathVariable("id") Integer id, @Valid @RequestBody MotivoCancelamentoDto motivoCancelamentoDto);
 }

--- a/src/main/java/com/api/doarmais/dtos/request/MotivoCancelamentoDto.java
+++ b/src/main/java/com/api/doarmais/dtos/request/MotivoCancelamentoDto.java
@@ -1,0 +1,13 @@
+package com.api.doarmais.dtos.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+public class MotivoCancelamentoDto {
+
+    @NotNull(message = "Motivo não pode ser nulo!")
+    @NotBlank(message = "Motivo deve ser preenchido!")
+    private String motivo;
+}

--- a/src/main/java/com/api/doarmais/events/PossivelPunicaoEvent.java
+++ b/src/main/java/com/api/doarmais/events/PossivelPunicaoEvent.java
@@ -1,12 +1,13 @@
 package com.api.doarmais.events;
 
+import com.api.doarmais.models.tabelas.AutenticacaoEmailModel;
 import com.api.doarmais.models.tabelas.PropostaModel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class PropostaCanceladaEdicaoAnuncioEvent {
+public class PossivelPunicaoEvent {
 
   private PropostaModel propostaModel;
 }

--- a/src/main/java/com/api/doarmais/events/PropostaCanceladaAnuncioEvent.java
+++ b/src/main/java/com/api/doarmais/events/PropostaCanceladaAnuncioEvent.java
@@ -1,0 +1,13 @@
+package com.api.doarmais.events;
+
+import com.api.doarmais.models.tabelas.PropostaModel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PropostaCanceladaAnuncioEvent {
+
+  private PropostaModel propostaModel;
+  private String motivo;
+}

--- a/src/main/java/com/api/doarmais/models/tabelas/PunicaoModel.java
+++ b/src/main/java/com/api/doarmais/models/tabelas/PunicaoModel.java
@@ -1,0 +1,41 @@
+package com.api.doarmais.models.tabelas;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Table(name = "punicao")
+public class PunicaoModel {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "id")
+  private Integer id;
+
+  @Column(name = "id_usuario")
+  private Integer idUsuario;
+
+  @Column(name = "id_situacao")
+  private Integer idSituacao;
+
+  @DateTimeFormat(pattern = "dd/MM/yyyy HH:mm:ss")
+  @Column(name = "data_agendada")
+  private LocalDateTime dataAgendada;
+
+  @DateTimeFormat(pattern = "dd/MM/yyyy HH:mm:ss")
+  @Column(name = "data_cancelamento")
+  private LocalDateTime dataCancelamento;
+
+  @Column(name = "motivo")
+  private String motivo;
+}

--- a/src/main/java/com/api/doarmais/models/tabelas/SituacaoModel.java
+++ b/src/main/java/com/api/doarmais/models/tabelas/SituacaoModel.java
@@ -38,6 +38,9 @@ public class SituacaoModel {
   public static final Integer DENUNCIA_CRIADA = 41;
   public static final Integer DENUNCIA_GERENCIADA = 42;
 
+  public static final Integer PUNICAO_NAO_VERIFICADA = 51;
+  public static final Integer PUNICAO_VERIFICADA = 52;
+
   @Id
   @NonNull
   @Column(name = "id")

--- a/src/main/java/com/api/doarmais/notifications/NotificadorPossivelPunicao.java
+++ b/src/main/java/com/api/doarmais/notifications/NotificadorPossivelPunicao.java
@@ -1,0 +1,45 @@
+package com.api.doarmais.notifications;
+
+import com.api.doarmais.events.PossivelPunicaoEvent;
+import com.api.doarmais.events.ResetCriadoEvent;
+import com.api.doarmais.models.tabelas.PropostaModel;
+import com.api.doarmais.models.tabelas.UsuarioModel;
+import com.api.doarmais.services.UsuarioService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.event.EventListener;
+import org.springframework.mail.MailSendException;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@EnableAsync
+@Configuration
+public class NotificadorPossivelPunicao implements Notificador<PossivelPunicaoEvent> {
+
+  @Autowired private UsuarioService usuarioService;
+
+  @Autowired private JavaMailSender sender;
+
+  @EventListener
+  @Async
+  public void enviar(PossivelPunicaoEvent possivelPunicaoEvent) {
+    PropostaModel proposta = possivelPunicaoEvent.getPropostaModel();
+    SimpleMailMessage message = new SimpleMailMessage();
+    UsuarioModel usuario = usuarioService.buscarUsuarioPorEmail(proposta.getAnuncioModel().getUsuarioModel().getEmail());
+
+    message.setSubject("Doar+ - Possível punição");
+    message.setText("Olá, " + usuario.getNome() + "!\n\n" +
+                    "Uma punição pode ser aplicada na sua conta por conta de um cancelamento de proposta!\n" +
+                    "O administrador irá verificar a data/horário do cancelamento com a data agendada para a proposta.");
+    message.setTo(usuario.getEmail());
+    message.setFrom("doar.mais@outlook.com");
+
+    try {
+      sender.send(message);
+    } catch (Exception e) {
+      throw new MailSendException(e.getMessage());
+    }
+  }
+}

--- a/src/main/java/com/api/doarmais/notifications/NotificadorPropostaCanceladaAnuncio.java
+++ b/src/main/java/com/api/doarmais/notifications/NotificadorPropostaCanceladaAnuncio.java
@@ -1,10 +1,8 @@
 package com.api.doarmais.notifications;
 
-import com.api.doarmais.events.PropostaCanceladaEdicaoAnuncioEvent;
-import com.api.doarmais.events.PropostaCriadaEvent;
+import com.api.doarmais.events.PropostaCanceladaAnuncioEvent;
 import com.api.doarmais.models.tabelas.ItemAnuncioPropostaModel;
 import com.api.doarmais.models.tabelas.PropostaModel;
-import com.api.doarmais.models.tabelas.UsuarioModel;
 import com.api.doarmais.services.ItemAnuncioPropostaService;
 import com.api.doarmais.services.UsuarioService;
 import jakarta.mail.MessagingException;
@@ -22,7 +20,7 @@ import java.util.List;
 
 @EnableAsync
 @Configuration
-public class NotificadorPropostaCanceladaEdicaoAnuncio implements Notificador<PropostaCanceladaEdicaoAnuncioEvent> {
+public class NotificadorPropostaCanceladaAnuncio implements Notificador<PropostaCanceladaAnuncioEvent> {
 
   @Autowired private JavaMailSender sender;
 
@@ -32,7 +30,7 @@ public class NotificadorPropostaCanceladaEdicaoAnuncio implements Notificador<Pr
 
   @EventListener
   @Async
-  public void enviar(PropostaCanceladaEdicaoAnuncioEvent propostaCanceladaEdicaoAnuncioEvent) throws MessagingException {
+  public void enviar(PropostaCanceladaAnuncioEvent propostaCanceladaEdicaoAnuncioEvent) throws MessagingException {
     SimpleMailMessage message = new SimpleMailMessage();
 
     PropostaModel proposta = propostaCanceladaEdicaoAnuncioEvent.getPropostaModel();
@@ -50,7 +48,7 @@ public class NotificadorPropostaCanceladaEdicaoAnuncio implements Notificador<Pr
     message.setText("Olá, " + proposta.getUsuarioModel().getNome() + "!\n\n" +
                     "Sua proposta - " + proposta.getAnuncioModel().getTitulo() + "\n\n" + itens +
                     "Agendada para - " + proposta.getDataAgendada().format(DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm:ss")) + "\n" +
-                    "Foi cancelada, pois a pessoa que criou precisou editar o anúncio!");
+            propostaCanceladaEdicaoAnuncioEvent.getMotivo());
 
     try {
       sender.send(message);

--- a/src/main/java/com/api/doarmais/notifications/NotificadorPropostaCriada.java
+++ b/src/main/java/com/api/doarmais/notifications/NotificadorPropostaCriada.java
@@ -66,9 +66,9 @@ public class NotificadorPropostaCriada implements Notificador<PropostaCriadaEven
                       "Quantidade - " + item.getQuantidadeSolicitada() + "<br><br>";
     }
 
-    String botoes = "<a href=\"https://localhost:8080/doacao/" + proposta.getAnuncioModel().getId() + "\"><button style=\"padding: 8px; font-weight: bold; background-color: #5865F2; border-radius: 9px; border-style: none; color: white;\">VER ANÚNCIO</button></a>\n" +
-                    "<a href=\"\"><button style=\"padding: 8px; font-weight: bold; background-color: #27AE60; border-radius: 9px; border-style: none; color: white;\">ACEITAR</button></a>\n" +
-                    "<a href=\"\"><button style=\"padding: 8px; font-weight: bold; background-color: #FF8164; border-radius: 9px; border-style: none; color: white;\">RECUSAR</button></a>";
+    String botoes = "<a href=\"https://localhost:8080/doacao/" + proposta.getAnuncioModel().getId() + "\"><button style=\"padding: 8px; font-weight: bold; background-color: #5865F2; border-radius: 9px; border-style: none; color: white; cursor: pointer;\">VER ANÚNCIO</button></a>\n" +
+                    "<a href=\"\"><button style=\"padding: 8px; font-weight: bold; background-color: #27AE60; border-radius: 9px; border-style: none; color: white; cursor: pointer;\">ACEITAR</button></a>\n" +
+                    "<a href=\"\"><button style=\"padding: 8px; font-weight: bold; background-color: #FF8164; border-radius: 9px; border-style: none; color: white; cursor: pointer;\">RECUSAR</button></a>";
 
     helper.setText(titulo + "" + conteudo + "" + anuncio + "" + itensPedidos + "" + botoes, true);
 

--- a/src/main/java/com/api/doarmais/repositories/PunicaoRepository.java
+++ b/src/main/java/com/api/doarmais/repositories/PunicaoRepository.java
@@ -1,0 +1,9 @@
+package com.api.doarmais.repositories;
+
+import com.api.doarmais.models.tabelas.AnuncioModel;
+import com.api.doarmais.models.tabelas.PunicaoModel;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PunicaoRepository extends JpaRepository<PunicaoModel, Integer> {}

--- a/src/main/java/com/api/doarmais/services/AnuncioService.java
+++ b/src/main/java/com/api/doarmais/services/AnuncioService.java
@@ -158,9 +158,13 @@ public class AnuncioService {
     }
 
   public void verificarEnvioPunicao(List<PropostaModel> propostasCanceladas, MotivoCancelamentoDto motivo) {
+    boolean envioEmail = false;
     for (PropostaModel proposta : propostasCanceladas) {
       if(LocalDateTime.now(ZoneId.of("America/Sao_Paulo")).isAfter(proposta.getDataAgendada().minusHours(3))){
-        eventPublisher.publishEvent(new PossivelPunicaoEvent(proposta));
+        if(!envioEmail){
+          eventPublisher.publishEvent(new PossivelPunicaoEvent(proposta));
+          envioEmail = true;
+        }
         punicaoService.gerarVerificacaoPunicao(proposta, motivo);
       }
     }

--- a/src/main/java/com/api/doarmais/services/PropostaService.java
+++ b/src/main/java/com/api/doarmais/services/PropostaService.java
@@ -3,7 +3,7 @@ package com.api.doarmais.services;
 import com.api.doarmais.dtos.request.PropostaRequestDto;
 import com.api.doarmais.dtos.response.ItemPropostaResponseDto;
 import com.api.doarmais.dtos.response.PropostaResponseDto;
-import com.api.doarmais.events.PropostaCanceladaEdicaoAnuncioEvent;
+import com.api.doarmais.events.PropostaCanceladaAnuncioEvent;
 import com.api.doarmais.models.tabelas.*;
 import com.api.doarmais.repositories.*;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -64,12 +64,12 @@ public class PropostaService {
     propostaRepository.save(proposta);
   }
 
-  public List<PropostaModel> cancelarTodasPropostasDoAnuncio(Integer id) {
+  public List<PropostaModel> cancelarTodasPropostasDoAnuncio(Integer id, String motivo) {
     AnuncioModel anuncioModel = anuncioRepository.findById(id).get();
     List<PropostaModel> propostaModelList = propostaRepository.buscarPorAnuncioIdQuery(id);
 
     for (PropostaModel proposta : propostaModelList)
-      eventPublisher.publishEvent(new PropostaCanceladaEdicaoAnuncioEvent(proposta));
+      eventPublisher.publishEvent(new PropostaCanceladaAnuncioEvent(proposta, motivo));
 
     propostaRepository.cancelarTodasPropostaAnuncioQuery(id);
     return propostaModelList;
@@ -85,7 +85,7 @@ public class PropostaService {
 
       propostaRepository.propostaEmAnaliseQuery(propostaModel.getId());
 
-      eventPublisher.publishEvent(new PropostaCanceladaEdicaoAnuncioEvent(propostaModel));
+      eventPublisher.publishEvent(new PropostaCanceladaAnuncioEvent(propostaModel, "Foi cancelada, pois a pessoa que criou precisou editar o anúncio!"));
 
     }
 

--- a/src/main/java/com/api/doarmais/services/PunicaoService.java
+++ b/src/main/java/com/api/doarmais/services/PunicaoService.java
@@ -1,0 +1,32 @@
+package com.api.doarmais.services;
+
+import com.api.doarmais.dtos.request.CriarUsuarioRequestDto;
+import com.api.doarmais.dtos.request.MotivoCancelamentoDto;
+import com.api.doarmais.models.tabelas.*;
+import com.api.doarmais.repositories.EnderecoRepository;
+import com.api.doarmais.repositories.PunicaoRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Optional;
+
+@Service
+public class PunicaoService {
+
+  @Autowired private PunicaoRepository punicaoRepository;
+
+  public void gerarVerificacaoPunicao(PropostaModel proposta, MotivoCancelamentoDto motivo) {
+    UsuarioModel usuarioModel =  (UsuarioModel) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+    PunicaoModel punicaoModel = new PunicaoModel();
+
+    punicaoModel.setIdUsuario(usuarioModel.getId());
+    punicaoModel.setDataAgendada(proposta.getDataAgendada());
+    punicaoModel.setDataCancelamento(LocalDateTime.now(ZoneId.of("America/Sao_Paulo")));
+    punicaoModel.setMotivo(motivo.getMotivo());
+    punicaoModel.setIdSituacao(SituacaoModel.PUNICAO_NAO_VERIFICADA);
+    punicaoRepository.save(punicaoModel);
+  }
+}


### PR DESCRIPTION
Usuário consegue cancelar anúncio;
Propostas vinculadas a eles são canceladas e um email é enviado para o usuário informando sobre o cancelamento;
Um controle é feito para enviar uma solicitação de punição que será aplicada pelo administrador.