### PR TITLE
Ajuste na troca de senha e endereço na área de perfil do usuário

### DIFF
--- a/database/01-scriptDoarMais.sql
+++ b/database/01-scriptDoarMais.sql
@@ -42,7 +42,6 @@ create table endereco(
     logradouro varchar(200),
     numero int,
     complemento varchar(100),
-    ativo int,
     primary key (id, id_usuario),
     foreign key (id_usuario) references usuario (id)
 );
@@ -164,6 +163,20 @@ create table punicao(
     primary key (id)
 );
 
+create table troca_endereco(
+	id int not null auto_increment,
+    id_usuario int,
+    cep varchar(8),
+    uf char(2),
+    cidade varchar(150),
+    bairro varchar(150),
+    logradouro varchar(200),
+    numero int,
+    complemento varchar(100),
+    comprovante_residencia blob,
+    primary key (id, id_usuario)
+);
+
 -- FIM BANCO
 
 -- CRIAÇÃO DAS VIEWS
@@ -192,9 +205,7 @@ from
 join
 	endereco e
 on
-	(u.id = e.id_usuario)
-where
-	e.ativo = 1;
+	(u.id = e.id_usuario);
 
 -- drop view if exists vw_busca_anuncio
 create view

--- a/database/02-createInitialize.sql
+++ b/database/02-createInitialize.sql
@@ -32,7 +32,9 @@ insert into situacao values
 (41, 'Denúncia criada'),
 (42, 'Denúncia gerenciada'),
 (51, 'Punição não verificada'),
-(52, 'Punição verificada');
+(52, 'Punição verificada'),
+(61, 'Solicitação troca de endereço pendente'),
+(62, 'Solicitação analisada');
 
 insert into tipo_anuncio values
 (1, 'Doação'),

--- a/database/04-createAddress.sql
+++ b/database/04-createAddress.sql
@@ -1,3 +1,3 @@
 insert into endereco values
-(1, 1, '11533040', 'SP', 'Cubatão', 'Jardim Casqueiro', 'Rau Estados Unidos', 530, '', 1),
-(2, 2, '11355030', 'SP', 'São Vicente', 'Vila Nossa Senhora de Fátima', 'Rua Tambaú', 286, '', 1);
+(1, 1, '11533040', 'SP', 'Cubatão', 'Jardim Casqueiro', 'Rau Estados Unidos', 530, ''),
+(2, 2, '11355030', 'SP', 'São Vicente', 'Vila Nossa Senhora de Fátima', 'Rua Tambaú', 286, '');

--- a/src/main/java/com/api/doarmais/controllers/DoacaoControllerImpl.java
+++ b/src/main/java/com/api/doarmais/controllers/DoacaoControllerImpl.java
@@ -90,7 +90,7 @@ public class DoacaoControllerImpl implements AnuncioController {
             (UsuarioModel) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
 
     if (cidade == null || cidade.isBlank()) {
-      var enderecoAtivo = enderecoService.buscarEnderecoAtivo(usuarioLogado.getId());
+      var enderecoAtivo = enderecoService.buscarEndereco(usuarioLogado.getId());
       cidade = enderecoAtivo.getCidade();
     }
 

--- a/src/main/java/com/api/doarmais/controllers/DoacaoRapidaControllerImpl.java
+++ b/src/main/java/com/api/doarmais/controllers/DoacaoRapidaControllerImpl.java
@@ -90,7 +90,7 @@ public class DoacaoRapidaControllerImpl implements AnuncioController {
             (UsuarioModel) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
 
     if (cidade == null || cidade.isBlank()) {
-      var enderecoAtivo = enderecoService.buscarEnderecoAtivo(usuarioLogado.getId());
+      var enderecoAtivo = enderecoService.buscarEndereco(usuarioLogado.getId());
       cidade = enderecoAtivo.getCidade();
     }
 

--- a/src/main/java/com/api/doarmais/controllers/PedidoControllerImpl.java
+++ b/src/main/java/com/api/doarmais/controllers/PedidoControllerImpl.java
@@ -89,7 +89,7 @@ public class PedidoControllerImpl implements AnuncioController {
     var usuarioLogado =
             (UsuarioModel) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
     if (cidade == null || cidade.isBlank()) {
-      var enderecoAtivo = enderecoService.buscarEnderecoAtivo(usuarioLogado.getId());
+      var enderecoAtivo = enderecoService.buscarEndereco(usuarioLogado.getId());
       cidade = enderecoAtivo.getCidade();
     }
 

--- a/src/main/java/com/api/doarmais/controllers/ResetSenhaControllerImpl.java
+++ b/src/main/java/com/api/doarmais/controllers/ResetSenhaControllerImpl.java
@@ -71,7 +71,7 @@ public class ResetSenhaControllerImpl implements ResetSenhaController {
     if (!resetSenhaModel.getId().equals(SituacaoModel.TOKEN_UTILIZADO))
       throw new LinkAlreadyUsed("Esse link já foi utilizado para alterar a senha");
 
-    if (!trocarSenhaRequestDto.getSenha().equals(trocarSenhaRequestDto.getConfirmaSenha()))
+    if (!trocarSenhaRequestDto.getNovaSenha().equals(trocarSenhaRequestDto.getConfirmaSenha()))
       throw new PasswordNotEqual("As senhas devem ser iguais");
 
     resetSenhaModel.setId(SituacaoModel.TOKEN_UTILIZADO);
@@ -79,7 +79,7 @@ public class ResetSenhaControllerImpl implements ResetSenhaController {
     UsuarioModel usuarioModel =
         usuarioService.buscarUsuarioPorEmail(resetSenhaModel.getEmailUsuario());
 
-    usuarioModel.setSenha(passwordEncoder.encode(trocarSenhaRequestDto.getSenha()));
+    usuarioModel.setSenha(passwordEncoder.encode(trocarSenhaRequestDto.getNovaSenha()));
     return new ResponseEntity<UsuarioResponseDto>(
         modelMapper.map(usuarioService.gravar(usuarioModel), UsuarioResponseDto.class),
         HttpStatus.OK);

--- a/src/main/java/com/api/doarmais/controllers/interfaces/UsuarioController.java
+++ b/src/main/java/com/api/doarmais/controllers/interfaces/UsuarioController.java
@@ -2,6 +2,7 @@ package com.api.doarmais.controllers.interfaces;
 
 import com.api.doarmais.dtos.request.AtualizarDadosRequestDto;
 import com.api.doarmais.dtos.request.EnderecoRequestDto;
+import com.api.doarmais.dtos.request.TrocarSenhaLogadoRequestDto;
 import com.api.doarmais.dtos.request.TrocarSenhaRequestDto;
 import com.api.doarmais.dtos.response.EnderecoResponseDto;
 import com.api.doarmais.dtos.response.UsuarioResponseDto;
@@ -31,15 +32,11 @@ public interface UsuarioController {
 
   @Operation(description = "Endpoint utilizado para criar um endereço.")
   @PostMapping("/enderecos")
-  public ResponseEntity<EnderecoResponseDto> criarEndereco(
+  public ResponseEntity<EnderecoResponseDto> solicitarTrocaEndereco(
       @Valid @RequestBody EnderecoRequestDto enderecoRequestDto);
-
-  @Operation(description = "Endpoint utilizado para deletar endereço.")
-  @DeleteMapping("/enderecos/{idEndereco}")
-  public ResponseEntity<HttpStatus> deletarEndereco(@PathVariable("idEndereco") Integer idEndereco);
 
   @Operation(description = "Endpoint utilizado para trocar a senha.")
   @PatchMapping("/senha")
   public ResponseEntity<UsuarioResponseDto> trocarSenha(
-      @Valid @RequestBody TrocarSenhaRequestDto trocarSenhaRequestDto);
+      @Valid @RequestBody TrocarSenhaLogadoRequestDto trocarSenhaLogadoRequestDto);
 }

--- a/src/main/java/com/api/doarmais/dtos/request/AtualizarDadosRequestDto.java
+++ b/src/main/java/com/api/doarmais/dtos/request/AtualizarDadosRequestDto.java
@@ -18,6 +18,4 @@ public class AtualizarDadosRequestDto {
   @Size(min = 10, max = 11, message = "Telefone deve conter entre 10 e 11 números!")
   private String telefone;
 
-  @NotNull(message = "Id endereço não pode ser nulo!")
-  private Integer idEndereco;
 }

--- a/src/main/java/com/api/doarmais/dtos/request/EnderecoRequestDto.java
+++ b/src/main/java/com/api/doarmais/dtos/request/EnderecoRequestDto.java
@@ -38,4 +38,6 @@ public class EnderecoRequestDto {
 
   @Size(max = 100, message = "Compelemento deve conter no máximo 100 caracteres!")
   private String complemento;
+
+  private String comprovanteResidencia;
 }

--- a/src/main/java/com/api/doarmais/dtos/request/TrocarSenhaLogadoRequestDto.java
+++ b/src/main/java/com/api/doarmais/dtos/request/TrocarSenhaLogadoRequestDto.java
@@ -6,7 +6,12 @@ import jakarta.validation.constraints.Size;
 import lombok.Data;
 
 @Data
-public class TrocarSenhaRequestDto {
+public class TrocarSenhaLogadoRequestDto {
+
+  @NotNull(message = "Senha atual não pode ser nula")
+  @NotBlank(message = "Senha atual deve ser preenchida")
+  @Size(max = 20, message = "Senha atual deve ter no máximo 20 caracteres")
+  private String senhaAtual;
 
   @NotNull(message = "Nova senha não pode ser nula")
   @NotBlank(message = "Nova senha deve ser preenchida")

--- a/src/main/java/com/api/doarmais/models/tabelas/SituacaoModel.java
+++ b/src/main/java/com/api/doarmais/models/tabelas/SituacaoModel.java
@@ -41,6 +41,9 @@ public class SituacaoModel {
   public static final Integer PUNICAO_NAO_VERIFICADA = 51;
   public static final Integer PUNICAO_VERIFICADA = 52;
 
+  public static final Integer SOLICITACAO_TROCA_ENDERECO_POENDENTE = 61;
+  public static final Integer SOLICITACAO_ANALISADA = 62;
+
   @Id
   @NonNull
   @Column(name = "id")

--- a/src/main/java/com/api/doarmais/models/tabelas/TrocaEnderecoModel.java
+++ b/src/main/java/com/api/doarmais/models/tabelas/TrocaEnderecoModel.java
@@ -11,17 +11,19 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-@Table(name = "endereco")
-public class EnderecoModel {
+@Table(name = "troca_endereco")
+public class TrocaEnderecoModel {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "id")
   private Integer id;
 
-  @ManyToOne
-  @JoinColumn(name = "id_usuario")
-  private UsuarioModel usuarioModel;
+  @Column(name = "id_usuario")
+  private Integer idUsuario;
+
+  @Column(name = "id_situacao")
+  private Integer idSituacao;
 
   @Column(name = "cep")
   private String cep;
@@ -43,5 +45,8 @@ public class EnderecoModel {
 
   @Column(name = "complemento")
   private String complemento;
+
+  @Column(name = "comprovante_residencia")
+  private String comprovanteResidencia;
 
 }

--- a/src/main/java/com/api/doarmais/repositories/EnderecoRepository.java
+++ b/src/main/java/com/api/doarmais/repositories/EnderecoRepository.java
@@ -9,8 +9,8 @@ import org.springframework.stereotype.Repository;
 public interface EnderecoRepository extends JpaRepository<EnderecoModel, Integer> {
   boolean existsByCepAndNumeroAndUsuarioModelId(String cep, Integer numero, Integer usuario);
 
-  EnderecoModel findByUsuarioModelIdAndAtivo(Integer usuario, int ativo);
-
   @Query("select count(t) from EnderecoModel t where t.usuarioModel.id = ?1")
   Integer verificarQtdEnderecoQuery(Integer idUsuario);
+
+  EnderecoModel findByUsuarioModelId(Integer idUsuario);
 }

--- a/src/main/java/com/api/doarmais/repositories/TrocaEnderecoRepository.java
+++ b/src/main/java/com/api/doarmais/repositories/TrocaEnderecoRepository.java
@@ -1,0 +1,9 @@
+package com.api.doarmais.repositories;
+
+import com.api.doarmais.models.tabelas.TrocaEnderecoModel;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TrocaEnderecoRepository extends JpaRepository<TrocaEnderecoModel, Integer> {
+}

--- a/src/main/java/com/api/doarmais/services/EnderecoService.java
+++ b/src/main/java/com/api/doarmais/services/EnderecoService.java
@@ -25,19 +25,10 @@ public class EnderecoService {
     enderecoModel.setLogradouro(criarUsuarioRequestDto.getLogradouro());
     enderecoModel.setNumero(criarUsuarioRequestDto.getNumero());
     enderecoModel.setComplemento(criarUsuarioRequestDto.getComplemento());
-    enderecoModel.setAtivo(1);
   }
 
   public EnderecoModel gravar(EnderecoModel enderecoModel) {
     return enderecoRepository.save(enderecoModel);
-  }
-
-  public boolean verificarEnderecoExistente(String cep, Integer numero, Integer usuario) {
-    return enderecoRepository.existsByCepAndNumeroAndUsuarioModelId(cep, numero, usuario);
-  }
-
-  public EnderecoModel buscarEnderecoAtivo(Integer usuario) {
-    return enderecoRepository.findByUsuarioModelIdAndAtivo(usuario, 1);
   }
 
   public Optional<EnderecoModel> buscarNovoEndereco(Integer endereco) {
@@ -50,5 +41,9 @@ public class EnderecoService {
 
   public Integer verificarQtdEndereco(Integer idUsuario) {
     return enderecoRepository.verificarQtdEnderecoQuery(idUsuario);
+  }
+
+  public EnderecoModel buscarEndereco(Integer idUsuario) {
+    return enderecoRepository.findByUsuarioModelId(idUsuario);
   }
 }

--- a/src/main/java/com/api/doarmais/services/ResetSenhaService.java
+++ b/src/main/java/com/api/doarmais/services/ResetSenhaService.java
@@ -2,6 +2,7 @@ package com.api.doarmais.services;
 
 import com.api.doarmais.models.tabelas.ResetSenhaModel;
 import com.api.doarmais.models.tabelas.SituacaoModel;
+import com.api.doarmais.models.tabelas.UsuarioModel;
 import com.api.doarmais.repositories.ResetSenhaRepository;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -10,6 +11,8 @@ import java.util.TimeZone;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -62,4 +65,5 @@ public class ResetSenhaService {
         .getDataValidade()
         .isBefore(LocalDateTime.now(ZoneId.of(TimeZone.getDefault().getID())));
   }
+
 }

--- a/src/main/java/com/api/doarmais/services/TrocaEnderecoService.java
+++ b/src/main/java/com/api/doarmais/services/TrocaEnderecoService.java
@@ -1,0 +1,29 @@
+package com.api.doarmais.services;
+
+import com.api.doarmais.dtos.request.CriarUsuarioRequestDto;
+import com.api.doarmais.dtos.request.EnderecoRequestDto;
+import com.api.doarmais.models.tabelas.EnderecoModel;
+import com.api.doarmais.models.tabelas.SituacaoModel;
+import com.api.doarmais.models.tabelas.TrocaEnderecoModel;
+import com.api.doarmais.models.tabelas.UsuarioModel;
+import com.api.doarmais.repositories.EnderecoRepository;
+import com.api.doarmais.repositories.TrocaEnderecoRepository;
+import org.springframework.beans.BeanUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class TrocaEnderecoService {
+
+  @Autowired private TrocaEnderecoRepository trocaEnderecoRepository;
+
+  public TrocaEnderecoModel criarSolicitacao(EnderecoRequestDto enderecoRequestDto, UsuarioModel usuarioModel) {
+    TrocaEnderecoModel trocaEnderecoModel = new TrocaEnderecoModel();
+    BeanUtils.copyProperties(enderecoRequestDto, trocaEnderecoModel);
+    trocaEnderecoModel.setIdUsuario(usuarioModel.getId());
+    trocaEnderecoModel.setIdSituacao(SituacaoModel.SOLICITACAO_TROCA_ENDERECO_POENDENTE);
+    return trocaEnderecoRepository.save(trocaEnderecoModel);
+  }
+}

--- a/src/main/java/com/api/doarmais/services/UsuarioService.java
+++ b/src/main/java/com/api/doarmais/services/UsuarioService.java
@@ -7,6 +7,7 @@ import com.api.doarmais.repositories.UsuarioRepository;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -86,4 +87,8 @@ public class UsuarioService {
       return false;
     }
   }
+
+    public boolean verificarSenhaAtual(String senhaAtual, PasswordEncoder passwordEncoder, UsuarioModel usuarioLogado) {
+      return (passwordEncoder.matches(senhaAtual, usuarioLogado.getSenha()));
+    }
 }


### PR DESCRIPTION
Necessário informar senha atual caso a troca de senha ocorra na área de perfil do usuário;
Remoção da troca de endereço e criar/deletar vários, agora só é possível ter um endereço por vez e, caso queria trocar, precisa enviar uma solicitação para o ADM e esperar ele aceitar.